### PR TITLE
Changes to data model & some endpoints

### DIFF
--- a/src/Api/Endpoints/Events/Create.cs
+++ b/src/Api/Endpoints/Events/Create.cs
@@ -1,6 +1,5 @@
 using Domain.Common;
 using Domain.Entities.CompanyHierarchy;
-using Domain.Entities.TaskAggregate;
 using Domain.Interfaces;
 using Domain.Specifications;
 using FastEndpoints;

--- a/src/Api/Endpoints/Jobs/Create.cs
+++ b/src/Api/Endpoints/Jobs/Create.cs
@@ -1,12 +1,14 @@
 using Domain.Entities;
 using Domain.Interfaces;
 using FastEndpoints;
+using Infrastructure;
 
 namespace Api.Endpoints.Jobs;
 
 public class Create : Endpoint<Create.Req, Create.Res>
 {
     public IRepository<Job> JobRepo { get; set; } = default!;
+    public IJobNameUniquenessChecker NameUniquenessChecker { get; set; } = default!;
 
     public class Req
     {
@@ -20,9 +22,6 @@ public class Create : Endpoint<Create.Req, Create.Res>
         public string Name { get; set; } = default!;
 
     }
-    
-    private static Job MapIn(Req r) =>
-        new(name: r.Name);
 
     private static Res MapOut(Job j) =>
         new()
@@ -30,7 +29,7 @@ public class Create : Endpoint<Create.Req, Create.Res>
             Id = j.Id,
             Name = j.Name
         };
-    
+
     public override void Configure()
     {
         Post(Api.Routes.Jobs.Create);
@@ -40,7 +39,7 @@ public class Create : Endpoint<Create.Req, Create.Res>
 
     public override async Task HandleAsync(Req req, CancellationToken ct)
     {
-        var job = MapIn(req);
+        var job = Job.Create(req.Name, NameUniquenessChecker).Unwrap();
 
         await JobRepo.AddAsync(job, ct);
 

--- a/src/Api/Endpoints/Jobs/Rename.cs
+++ b/src/Api/Endpoints/Jobs/Rename.cs
@@ -1,12 +1,14 @@
 using Domain.Entities;
 using Domain.Interfaces;
 using FastEndpoints;
+using Infrastructure;
 
 namespace Api.Endpoints.Jobs;
 
 public class Rename: Endpoint<Rename.Req, EmptyResponse>
 {
     public IRepository<Job> JobRepo { get; set; } = default!;
+    public IJobNameUniquenessChecker NameUniquenessChecker { get; set; } = default!;
 
     public class Req
     {
@@ -31,7 +33,7 @@ public class Rename: Endpoint<Rename.Req, EmptyResponse>
             return;
         }
 
-        job.Name = req.Name;
+        job.Rename(req.Name, NameUniquenessChecker).Unwrap();
 
         await JobRepo.SaveChangesAsync(ct);
         await SendNoContentAsync(ct);

--- a/src/Api/Endpoints/Locations/GetById.cs
+++ b/src/Api/Endpoints/Locations/GetById.cs
@@ -1,3 +1,4 @@
+using Domain.Common;
 using Domain.Entities.CompanyHierarchy;
 using Domain.Interfaces;
 using Domain.Specifications;
@@ -13,24 +14,76 @@ public class GetById : Endpoint<GetById.Req, GetById.Res>
     {
         public int Id { get; set; }
     }
+
     public class Res
     {
         public int Id { get; set; }
         public string Name { get; set; } = default!;
-        public DetectorRes? Detector { get; set; } = default!;
+        public bool HasSnapshot { get; set; }
 
+        public OngoingTaskRes? OngoingTask { get; set; }
 
-        public record DetectorRes(int Id, string Name);
+        public record EventRes(int Id, DateTime Timestamp, EventResult Result, StepRes Step);
+
+        public record StepRes(int Id, int? OrderNum, TemplateState ExInitState,
+            TemplateState ExSubsState, ObjectRes Object);
+
+        public record ObjectRes(int Id, string Name, ObjectCoordinates Coords);
+
+        public record OngoingTaskInstanceRes(int Id, TaskInstanceFinalState? FinalState,
+            IEnumerable<EventRes> Events, int CurrentOrderNum);
+
+        public record OngoingJobRes(int Id, string Name);
+
+        public record OngoingTaskRes(int Id, string Name, TaskType Type, TaskState State,
+            OngoingJobRes Job,
+            OngoingTaskInstanceRes? TaskInstance,
+            IEnumerable<StepRes> Steps,
+            int MaxOrderNum
+            );
     }
 
-    private static Res MapOut(Location l) =>
-     new()
+    private static Res MapOut(Location l)
+    {
+        var res = new Res
         {
             Id = l.Id,
             Name = l.Name,
-            Detector = l.Detector is null ? null
-                : new Res.DetectorRes(l.Detector.Id, l.Detector.Name)
+            HasSnapshot = l.Snapshot is not null
         };
+
+        // The specification only fetches the ongoing task, if there is one
+        var task = l.Tasks.FirstOrDefault();
+
+        if (task is null) return res;
+
+        var steps = task.Steps.Select(s => new Res.StepRes(s.Id, s.OrderNum, s.ExpectedInitialState,
+            s.ExpectedSubsequentState,
+            new Res.ObjectRes(s.Object.Id, s.Object.Name, s.Object.Coordinates))).ToList();
+
+        var jobRes = new Res.OngoingJobRes(task.Job.Id, task.Job.Name);
+
+        // Only the ongoing task instance is fetched, if there is one
+        var taskInstance = task.Instances.FirstOrDefault();
+
+        if (taskInstance is null)
+        {
+            res.OngoingTask = new Res.OngoingTaskRes(task.Id, task.Name, task.Type, task.State,
+                jobRes, null, steps, 0);
+            return res;
+        }
+
+        var taskInstanceRes = new Res.OngoingTaskInstanceRes(taskInstance.Id,
+            taskInstance.FinalState, taskInstance.Events
+                .Select(e =>
+                    new Res.EventRes(e.Id, e.Timestamp, e.Result,
+                        steps.First(s => s.Id == e.StepId))), 0);
+
+        res.OngoingTask = new Res.OngoingTaskRes(task.Id, task.Name, task.Type, task.State, jobRes,
+            taskInstanceRes, steps, 0);
+
+        return res;
+    }
 
     public override void Configure()
     {
@@ -41,7 +94,8 @@ public class GetById : Endpoint<GetById.Req, GetById.Res>
 
     public override async Task HandleAsync(Req req, CancellationToken ct)
     {
-        var location = await LocationRepo.FirstOrDefaultAsync(new LocationWithDetectorSpec(req.Id), ct);
+        var location =
+            await LocationRepo.FirstOrDefaultAsync(new LocationWithActiveTaskSpec(req.Id), ct);
 
         if (location is null)
         {
@@ -52,5 +106,4 @@ public class GetById : Endpoint<GetById.Req, GetById.Res>
         var res = MapOut(location);
         await SendOkAsync(res, ct);
     }
-
 }

--- a/src/Api/Endpoints/Stations/GetById.cs
+++ b/src/Api/Endpoints/Stations/GetById.cs
@@ -22,7 +22,7 @@ public class GetById : Endpoint<GetById.Req, GetById.Res>
 
         public IEnumerable<LocationRes> Locations { get; set; } = default!;
 
-        public record LocationRes(int Id, string Name, DetectorRes? Detector);
+        public record LocationRes(int Id, string Name, bool HasSnapshot, DetectorRes? Detector);
 
         public record DetectorRes(int Id, string Name, string MacAddress, DetectorState State);
     }
@@ -33,7 +33,7 @@ public class GetById : Endpoint<GetById.Req, GetById.Res>
             Id = s.Id,
             Name = s.Name,
             Locations = s.Children.Select(l =>
-                new Res.LocationRes(l.Id, l.Name,
+                new Res.LocationRes(l.Id, l.Name, l.Snapshot != null,
                     l.Detector is null
                         ? null
                         : new Res.DetectorRes(l.Detector.Id, l.Detector.Name, l.Detector.MacAddress.ToString(),

--- a/src/Api/Endpoints/Tasks/Create.cs
+++ b/src/Api/Endpoints/Tasks/Create.cs
@@ -1,12 +1,11 @@
+using Domain.Common;
 using Domain.Entities;
 using Domain.Entities.CompanyHierarchy;
 using Domain.Interfaces;
 
-using Domain.Entities.TaskAggregate;
 using Domain.Specifications;
 using FastEndpoints;
 
-using Object = Domain.Entities.TaskAggregate.Object;
 using Task = Domain.Entities.TaskAggregate.Task;
 
 namespace Api.Endpoints.Tasks;
@@ -20,6 +19,7 @@ public class Create: Endpoint<Create.Req, Create.Res>
         public int ParentJobId { get; set; }
         public string Name { get; set; } = default!;
         public int LocationId { get; set; }
+        public TaskType TaskType { get; set; }
     }
 
     public class Res
@@ -64,14 +64,13 @@ public class Create: Endpoint<Create.Req, Create.Res>
             return;
         }
 
-        var task = new Task(name: req.Name, objects: new List<Object>(), steps: new List<Step>(), req.LocationId);
+        var task = new Task(req.Name, req.LocationId, req.TaskType);
 
         job.Tasks.Add(task);
 
         await JobRepo.SaveChangesAsync(ct);
 
         var res = MapOut(task);
-
         await SendCreatedAtAsync<Create>(new { task.Id }, res, null, null, false, ct);
     }
 }

--- a/src/Api/Endpoints/Tasks/GetById.cs
+++ b/src/Api/Endpoints/Tasks/GetById.cs
@@ -21,31 +21,29 @@ public class GetById : Endpoint<GetById.Req, GetById.Res>
     {
         public int Id { get; set; }
         public string Name { get; set; } = default!;
-        public TaskState State { get; set; }
-        public ResInstance? LatestInstance { get; set; }
+        public int MaxOrderNum { get; set; }
+        public ResInstance? OngoingInstance { get; set; }
 
-        public record ResInstance(int Id, TaskInstanceFinalState? FinalState, IEnumerable<ResEvent> Events);
+        public record ResInstance(int Id, TaskInstanceState State, IEnumerable<ResEvent> Events);
 
         // TODO(rg): might need to extend with steps and objects
         public record ResEvent(DateTime Timestamp, bool Success, string? FailureReason);
 
     }
 
-    private static Res MapOut(Domain.Entities.TaskAggregate.Task t, TaskInstance? ti)
+    private static Res MapOut(Domain.Entities.TaskAggregate.Task t)
     {
         var res = new Res
         {
             Id = t.Id,
             Name = t.Name,
-            State = t.State
+            MaxOrderNum = t.MaxOrderNum
         };
 
-        if (ti is not null)
+        if (t.OngoingInstance is not null)
         {
-            var events = ti.Events.Select(e => new Res.ResEvent(e.Timestamp, e.Result.Success, e.Result.FailureReason));
-            var resInstance = new Res.ResInstance(ti.Id, ti.FinalState, events);
-
-            res.LatestInstance = resInstance;
+            var events = t.OngoingInstance.Events.Select(e => new Res.ResEvent(e.Timestamp, e.Result.Success, e.Result.FailureReason));
+            res.OngoingInstance = new Res.ResInstance(t.OngoingInstance.Id, t.OngoingInstance.State, events);
         }
 
         return res;
@@ -60,10 +58,8 @@ public class GetById : Endpoint<GetById.Req, GetById.Res>
 
     public override async Task HandleAsync(Req req, CancellationToken ct)
     {
-        var task = await TaskRepo.GetByIdAsync(req.Id, ct);
-        var latestInstance = await TaskInstanceRepo.FirstOrDefaultAsync(
-            new LatestTaskInstanceByTaskIdWithEventsSpec(req.Id), ct
-        );
+        var task = await TaskRepo.FirstOrDefaultAsync(
+            new TaskWithOngoingInstanceSpec(req.Id), ct);
 
         if (task is null)
         {
@@ -71,7 +67,7 @@ public class GetById : Endpoint<GetById.Req, GetById.Res>
             return;
         }
 
-        var res = MapOut(task, latestInstance);
+        var res = MapOut(task);
         await SendOkAsync(res, ct);
     }
 }

--- a/src/Api/Endpoints/Tasks/GetCurrentInstance.cs
+++ b/src/Api/Endpoints/Tasks/GetCurrentInstance.cs
@@ -18,7 +18,7 @@ public class GetCurrentInstance : Endpoint<GetCurrentInstance.Req, GetCurrentIns
     {
         public ResTaskInstance Instance { get; set; } = default!;
 
-        public record ResTaskInstance(int Id, TaskInstanceFinalState? FinalState, IEnumerable<ResEvent> Events, int TaskId);
+        public record ResTaskInstance(int Id, TaskInstanceState? FinalState, IEnumerable<ResEvent> Events, int TaskId);
 
         public record ResEvent(int Id, DateTime TimeStamp, bool EventResultSuccess, string? FailureReason, int StepId, int TaskInstanceId);
 
@@ -46,7 +46,7 @@ public class GetCurrentInstance : Endpoint<GetCurrentInstance.Req, GetCurrentIns
 
         var res = new Res
         {
-            Instance = new Res.ResTaskInstance(instance.Id, instance.FinalState, resEvents, instance.TaskId)
+            Instance = new Res.ResTaskInstance(instance.Id, instance.State, resEvents, instance.TaskId)
         };
 
         await SendOkAsync(res, ct);

--- a/src/Api/swagger.json
+++ b/src/Api/swagger.json
@@ -1,10 +1,15 @@
 {
-  "x-generator": "NSwag v13.17.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))",
+  "x-generator": "NSwag v13.17.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v9.0.0.0))",
   "openapi": "3.0.0",
   "info": {
-    "title": "dotnet-nswag",
+    "title": "Api",
     "version": "1.0.0"
   },
+  "servers": [
+    {
+      "url": "https://localhost:9696"
+    }
+  ],
   "paths": {
     "/api/v1/tasks": {
       "post": {
@@ -1310,6 +1315,38 @@
         }
       }
     },
+    "/api/v1/detectors/{id}/getinitialcalibrationdata": {
+      "get": {
+        "tags": [
+          "Detectors"
+        ],
+        "operationId": "ApiEndpointsDetectorsGetInitialCalibrationData",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {}
+              },
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/detectors/{MacAddress}/heartbeat": {
       "post": {
         "tags": [
@@ -1424,6 +1461,97 @@
                     "$ref": "#/components/schemas/DetectorsList_Res"
                   }
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/detectors/{locationId}/recalibrate": {
+      "get": {
+        "tags": [
+          "Detectors"
+        ],
+        "operationId": "ApiEndpointsDetectorsReCalibrate",
+        "parameters": [
+          {
+            "name": "locationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "NewTrayCoordinates",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/detectors/{id}/requestcalibrationpreview": {
+      "get": {
+        "tags": [
+          "Detectors"
+        ],
+        "operationId": "ApiEndpointsDetectorsRequestCalibrationPreview",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "NewTrayPoints",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {}
+              },
+              "application/json": {
+                "schema": {}
               }
             }
           }
@@ -2077,6 +2205,9 @@
             "type": "string",
             "nullable": true
           },
+          "HasSnapshot": {
+            "type": "boolean"
+          },
           "Detector": {
             "nullable": true,
             "oneOf": [
@@ -2345,17 +2476,20 @@
           "Name": {
             "type": "string"
           },
-          "Detector": {
+          "HasSnapshot": {
+            "type": "boolean"
+          },
+          "OngoingTask": {
             "nullable": true,
             "oneOf": [
               {
-                "$ref": "#/components/schemas/LocationsGetById_Res_DetectorRes"
+                "$ref": "#/components/schemas/LocationsGetById_Res_OngoingTaskRes"
               }
             ]
           }
         }
       },
-      "LocationsGetById_Res_DetectorRes": {
+      "LocationsGetById_Res_OngoingTaskRes": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -2366,6 +2500,168 @@
           "Name": {
             "type": "string",
             "nullable": true
+          },
+          "Type": {
+            "$ref": "#/components/schemas/TaskType"
+          },
+          "State": {
+            "$ref": "#/components/schemas/TaskState"
+          },
+          "Job": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LocationsGetById_Res_OngoingJobRes"
+              }
+            ]
+          },
+          "TaskInstance": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LocationsGetById_Res_OngoingTaskInstanceRes"
+              }
+            ]
+          },
+          "Steps": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/LocationsGetById_Res_StepRes"
+            }
+          }
+        }
+      },
+      "LocationsGetById_Res_OngoingJobRes": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "Name": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "LocationsGetById_Res_OngoingTaskInstanceRes": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "FinalState": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TaskInstanceFinalState"
+              }
+            ]
+          },
+          "Events": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/LocationsGetById_Res_EventRes"
+            }
+          }
+        }
+      },
+      "LocationsGetById_Res_EventRes": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "Timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "Result": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EventResult"
+              }
+            ]
+          },
+          "Step": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LocationsGetById_Res_StepRes"
+              }
+            ]
+          }
+        }
+      },
+      "EventResult": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Success": {
+            "type": "boolean"
+          },
+          "FailureReason": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "LocationsGetById_Res_StepRes": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "OrderNum": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "ExInitState": {
+            "$ref": "#/components/schemas/TemplateState"
+          },
+          "ExSubsState": {
+            "$ref": "#/components/schemas/TemplateState"
+          },
+          "Object": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LocationsGetById_Res_ObjectRes"
+              }
+            ]
+          }
+        }
+      },
+      "LocationsGetById_Res_ObjectRes": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "Coords": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ObjectCoordinates"
+              }
+            ]
           }
         }
       },
@@ -2635,6 +2931,10 @@
         "type": "object",
         "additionalProperties": false
       },
+      "DetectorsGetInitialCalibrationData_Req": {
+        "type": "object",
+        "additionalProperties": false
+      },
       "DetectorsHeartBeat_Req": {
         "type": "object",
         "additionalProperties": false,
@@ -2660,25 +2960,12 @@
           "MacAddress": {
             "type": "string"
           },
-          "Coordinates": {
+          "QrCoordinates": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DetectorsIdentify_Req_CalibrationCoordsReq"
+              "type": "integer",
+              "format": "int32"
             }
-          }
-        }
-      },
-      "DetectorsIdentify_Req_CalibrationCoordsReq": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "X": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "Y": {
-            "type": "integer",
-            "format": "int32"
           }
         }
       },
@@ -2725,6 +3012,14 @@
             "nullable": true
           }
         }
+      },
+      "DetectorsReCalibrate_Req": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "DetectorsRequestCalibrationPreview_Req": {
+        "type": "object",
+        "additionalProperties": false
       },
       "DetectorsSnapshot_Req": {
         "type": "object",

--- a/src/Application/Services/JobNameUniquenessChecker.cs
+++ b/src/Application/Services/JobNameUniquenessChecker.cs
@@ -1,0 +1,20 @@
+using Domain.Entities;
+using Domain.Interfaces;
+using Domain.Specifications;
+
+namespace Application.Services;
+
+public class JobNameUniquenessChecker : IJobNameUniquenessChecker
+{
+    private readonly IRepository<Job> _repo;
+
+    public JobNameUniquenessChecker(IRepository<Job> repo)
+    {
+        _repo = repo;
+    }
+
+    public async Task<bool> IsDuplicate(string name, Job? existingJob)
+    {
+        return await _repo.AnyAsync(new JobNameUniquenessSpec(name, existingJob));
+    }
+}

--- a/src/Domain/Common/TaskInstanceFinalState.cs
+++ b/src/Domain/Common/TaskInstanceFinalState.cs
@@ -1,7 +1,0 @@
-namespace Domain.Common;
-
-public enum TaskInstanceFinalState
-{
-    Completed,
-    Abandoned
-}

--- a/src/Domain/Common/TaskInstanceState.cs
+++ b/src/Domain/Common/TaskInstanceState.cs
@@ -1,0 +1,9 @@
+namespace Domain.Common;
+
+public enum TaskInstanceState
+{
+    Completed,
+    Abandoned,
+    InProgress,
+    Paused
+}

--- a/src/Domain/Entities/CompanyHierarchy/ICHNode.cs
+++ b/src/Domain/Entities/CompanyHierarchy/ICHNode.cs
@@ -10,18 +10,18 @@ public interface ICHNode<TParent, TChild>
 public interface ICHNodeWithParent<TParent> : ICHNode
     where TParent : class, ICHNode
 {
-    public TParent Parent { get; set; }
-    public int ParentId { get; set; }
+    public TParent Parent { get; }
+    public int ParentId { get; }
 }
 
 public interface ICHNodeWithChildren<TChild> : ICHNode
     where TChild : class, ICHNode
 {
-    public List<TChild> Children { get; set; }
+    public List<TChild> Children { get; }
 }
 
 public interface ICHNode : IBaseEntity
 {
-    public string Name { get; set; }
+    public string Name { get; }
 
 }

--- a/src/Domain/Entities/CompanyHierarchy/Line.cs
+++ b/src/Domain/Entities/CompanyHierarchy/Line.cs
@@ -5,12 +5,12 @@ namespace Domain.Entities.CompanyHierarchy;
 
 public class Line : ICHNode<OPU, Station>
 {
-    public int Id { get; set; }
-    public string Name { get; set; } = default!;
-    public List<Station> Children { get; set; } = default!;
+    public int Id { get; private set; }
+    public string Name { get; private set; } = default!;
+    public List<Station> Children { get; private set; } = default!;
 
-    public OPU Parent { get; set; } = default!;
-    public int ParentId { get; set; }
+    public OPU Parent { get; private set; } = default!;
+    public int ParentId { get; private set; }
 
     private Line() {}
     private Line(int id, string name, int parentId)

--- a/src/Domain/Entities/CompanyHierarchy/Location.cs
+++ b/src/Domain/Entities/CompanyHierarchy/Location.cs
@@ -8,24 +8,28 @@ namespace Domain.Entities.CompanyHierarchy;
 
 public class Location : ICHNodeWithParent<Station>
 {
-    public int Id { get; set; }
-    public string Name { get; set; } = default!;
-    public Station Parent { get; set; } = default!;
-    public int ParentId { get; set; }
-    public Detector? Detector { get; set; }
-    public List<Task> Tasks { get; set; } = default!;
-    public CalibrationCoordinates? Coordinates { get; set; } = default!;
+    public int Id { get; private set; }
+    public string Name { get; private set; } = default!;
+    public Station Parent { get; private set; } = default!;
+    public int ParentId { get; private set; }
+    public Detector? Detector { get; private set; }
+    public List<Task> Tasks { get; private set; } = default!;
+
+    public Task? OngoingTask { get; set; }
+    public int? OngoingTaskId { get; set; }
+    public CalibrationCoordinates? Coordinates { get; set; }
 
     public byte[]? Snapshot { get; set; }
 
     private Location() {}
 
-    private Location(int id, string name, int parentId, bool snapshot)
+    private Location(int id, string name, int parentId, bool snapshot, int? ongoingTaskId)
     {
         Id = id;
         Name = name;
         ParentId = parentId;
-        Snapshot = snapshot ? new[] { (byte) 2, (byte) 3 } : null ;
+        Snapshot = snapshot ? new[] { (byte) 2, (byte) 3 } : null;
+        OngoingTaskId = ongoingTaskId;
     }
 
     public Location(string name)
@@ -81,18 +85,18 @@ public class Location : ICHNodeWithParent<Station>
         return Ok();
     }
 
-    public async Task<Result> SendRecalibrate(IDetectorConnection DetectorConnection, int[]? newTrayCoordinates=null)
+    public async Task<Result> SendRecalibrate(IDetectorConnection detectorConnection, int[]? newTrayCoordinates=null)
     {
         if (Detector is null || Detector.State == DetectorState.Off)
         {
             return Fail("This location has no active detector!");
         }
 
-        var result = await Detector.SendRecalibrate(Coordinates, DetectorConnection, newTrayCoordinates);
+        var result = await Detector.SendRecalibrate(Coordinates, detectorConnection, newTrayCoordinates);
 
         Coordinates = result.Value;
 
         return Ok();
     }
-    
+
 }

--- a/src/Domain/Entities/CompanyHierarchy/OPU.cs
+++ b/src/Domain/Entities/CompanyHierarchy/OPU.cs
@@ -5,11 +5,11 @@ namespace Domain.Entities.CompanyHierarchy;
 
 public class OPU : ICHNodeWithParent<Site>, ICHNodeWithChildren<Line>
 {
-    public int Id { get; set; }
-    public string Name { get; set; } = default!;
-    public List<Line> Children { get; set; } = default!;
-    public Site Parent { get; set; } = default!;
-    public int ParentId { get; set; }
+    public int Id { get; private set; }
+    public string Name { get; private set; } = default!;
+    public List<Line> Children { get; private set; } = default!;
+    public Site Parent { get; private set; } = default!;
+    public int ParentId { get; private set; }
 
     private OPU() {}
     private OPU(int id, string name, int parentId)

--- a/src/Domain/Entities/CompanyHierarchy/Site.cs
+++ b/src/Domain/Entities/CompanyHierarchy/Site.cs
@@ -5,9 +5,9 @@ namespace Domain.Entities.CompanyHierarchy;
 
 public class Site : ICHNodeWithChildren<OPU>
 {
-    public int Id { get; set; }
-    public string Name { get; set; } = default!;
-    public List<OPU> Children { get; set; } = default!;
+    public int Id { get; private set; }
+    public string Name { get; private set; } = default!;
+    public List<OPU> Children { get; private set; } = default!;
 
     private Site() {}
 

--- a/src/Domain/Entities/CompanyHierarchy/Station.cs
+++ b/src/Domain/Entities/CompanyHierarchy/Station.cs
@@ -5,9 +5,9 @@ namespace Domain.Entities.CompanyHierarchy;
 
 public class Station : ICHNode<Line, Location>
 {
-    public int Id { get; set; }
-    public string Name { get; set; } = default!;
-    public List<Location> Children { get; set; } = default!;
+    public int Id { get; private set; }
+    public string Name { get; private set; } = default!;
+    public List<Location> Children { get; private set; } = default!;
 
     public Line Parent { get; set; } = default!;
     public int ParentId { get; set; }

--- a/src/Domain/Entities/Detector.cs
+++ b/src/Domain/Entities/Detector.cs
@@ -64,8 +64,8 @@ public class Detector : IBaseEntity
         }
 
         var result = await detectorConnection.SendCalibrationData(this, coords, newTrayPoints);
-        //we working with a location's detector so the location will always be something
-        Location.Coordinates = result.Value;
+        // we working with a location's detector so the location will always be something
+        Location!.Coordinates = result.Value;
 
         return Result.Ok(result.Value);
     }

--- a/src/Domain/Entities/Job.cs
+++ b/src/Domain/Entities/Job.cs
@@ -1,3 +1,4 @@
+using Domain.Interfaces;
 using FluentResults;
 using Task = Domain.Entities.TaskAggregate.Task;
 
@@ -5,9 +6,9 @@ namespace Domain.Entities;
 
 public class Job : IBaseEntity
 {
-    public int Id { get; set; }
-    public string Name { get; set; } = default!;
-    public List<Task> Tasks { get; set; } = default!;
+    public int Id { get; private set; }
+    public string Name { get; private set; } = default!;
+    public List<Task> Tasks { get; private set; } = default!;
 
     private Job()
     {
@@ -19,9 +20,22 @@ public class Job : IBaseEntity
         Name = name;
     }
 
-    public Job(string name)
+    public static Result<Job> Create(string name, IJobNameUniquenessChecker nameUniquenessChecker)
     {
-        Name = name;
+        if (nameUniquenessChecker.IsDuplicate(name, null).GetAwaiter().GetResult())
+            return Result.Fail("Duplicate name");
+
+        return Result.Ok(new Job { Name = name });
+    }
+
+    public Result Rename(string newName, IJobNameUniquenessChecker nameUniquenessChecker)
+    {
+        if (nameUniquenessChecker.IsDuplicate(newName, this).GetAwaiter().GetResult())
+            return Result.Fail("Duplicate name");
+
+        Name = newName;
+
+        return Result.Ok();
     }
 
     public void DeleteTask(Task task)

--- a/src/Domain/Entities/TaskAggregate/Event.cs
+++ b/src/Domain/Entities/TaskAggregate/Event.cs
@@ -4,16 +4,16 @@ namespace Domain.Entities.TaskAggregate;
 
 public class Event : IBaseEntity
 {
-    public int Id { get; set; }
-    public DateTime Timestamp { get; set; }
+    public int Id { get; private set; }
+    public DateTime Timestamp { get; private set; }
 
-    public EventResult Result { get; set; } = default!;
+    public EventResult Result { get; private set; } = default!;
 
-    public Step Step { get; set; } = default!;
-    public int StepId { get; set; }
+    public Step Step { get; private set; } = default!;
+    public int StepId { get; private set; }
 
-    public TaskInstance TaskInstance { get; set; } = default!;
-    public int TaskInstanceId { get; set; }
+    public TaskInstance TaskInstance { get; private set; } = default!;
+    public int TaskInstanceId { get; private set; }
 
     private Event() { }
 

--- a/src/Domain/Entities/TaskAggregate/Object.cs
+++ b/src/Domain/Entities/TaskAggregate/Object.cs
@@ -5,10 +5,10 @@ namespace Domain.Entities.TaskAggregate;
 
 public partial class Object : IBaseEntity
 {
-    public int Id { get; set; }
-    public string Name { get; set; } = default!;
-    public ObjectCoordinates Coordinates { get; set; } = default!;
-    public int TaskId { get; set; }
+    public int Id { get; private set; }
+    public string Name { get; private set; } = default!;
+    public ObjectCoordinates Coordinates { get; private set; } = default!;
+    public int TaskId { get; private set; }
 
     private Object()
     {

--- a/src/Domain/Entities/TaskAggregate/Step.cs
+++ b/src/Domain/Entities/TaskAggregate/Step.cs
@@ -6,21 +6,34 @@ namespace Domain.Entities.TaskAggregate;
 
 public class Step : IBaseEntity
 {
-    public int Id { get; set; }
-    public int? OrderNum { get; set; }
-    public TemplateState ExpectedInitialState { get; set; }
-    public TemplateState ExpectedSubsequentState { get; set; }
+    public int Id { get; private set; }
+    public int OrderNum { get; private set; }
+    public TemplateState ExpectedInitialState { get; private set; }
+    public TemplateState ExpectedSubsequentState { get; private set; }
 
-    public Object Object { get; set; } = default!;
-    public int ObjectId { get; set; }
+    public Object Object { get; private set; } = default!;
+    public int ObjectId { get; private set; }
 
-    public int TaskId { get; set; }
+    public int TaskId { get; private set; }
 
     private Step()
     {
     }
 
-    private Step(int id, int? orderNum, TemplateState init, TemplateState subs, int objectId, int taskId)
+    public Result Update(int orderNum, TemplateState init, TemplateState subs, Object obj)
+    {
+        if (!init.IsValid()) return Result.Fail("Invalid expected initial state");
+        if (!subs.IsValid()) return Result.Fail("Invalid subsequent initial state");
+
+        OrderNum = orderNum;
+        ExpectedInitialState = init;
+        ExpectedSubsequentState = subs;
+        Object = obj;
+
+        return Result.Ok();
+    }
+
+    private Step(int id, int orderNum, TemplateState init, TemplateState subs, int objectId, int taskId)
     {
         Id = id;
         OrderNum = orderNum;

--- a/src/Domain/Entities/TaskAggregate/Task.cs
+++ b/src/Domain/Entities/TaskAggregate/Task.cs
@@ -12,8 +12,11 @@ public class Task : IBaseEntity
     public TaskType Type { get; set; }
     public TaskState State { get; set; }
 
-    public int LocationId { get; set; }
+    public int MaxOrderNum { get; set; }
+
     public int JobId { get; set; }
+    public Job Job { get; set; } = default!;
+    public int LocationId { get; set; }
 
     public Location Location { get; set; } = default!;
     public List<TaskInstance> Instances { get; set; } = default!;
@@ -27,19 +30,22 @@ public class Task : IBaseEntity
         Id = id;
         Name = name;
         Type = type;
+        State = taskState;
+        MaxOrderNum = 0;
         LocationId = locationId;
         JobId = jobId;
         Instances = new List<TaskInstance>();
         Objects = new List<Object>();
         Steps = new List<Step>();
-        State = taskState;
     }
 
-    public Task(string name, List<Object> objects, List<Step> steps, int locationId)
+    public Task(string name, int locationId, TaskType taskType)
     {
         Name = name;
-        Objects = objects;
-        Steps = steps;
+        Type = taskType;
+        State = TaskState.Inactive;
+        Objects = new List<Object>();
+        Steps = new List<Step>();
         LocationId = locationId;
     }
 
@@ -176,10 +182,5 @@ public class Task : IBaseEntity
         State = TaskState.Active;
 
         return Result.Ok();
-    }
-
-    public bool IsObjectBelongsTo(int id)
-    {
-        return Objects.Any() && Objects.Select(o => o.Id).Contains(id);
     }
 }

--- a/src/Domain/Interfaces/IJobNameUniquenessChecker.cs
+++ b/src/Domain/Interfaces/IJobNameUniquenessChecker.cs
@@ -1,0 +1,8 @@
+using Domain.Entities;
+
+namespace Domain.Interfaces;
+
+public interface IJobNameUniquenessChecker
+{
+    public Task<bool> IsDuplicate(string name, Job? existingJob);
+}

--- a/src/Domain/Specifications/CurrentTaskInstanceWithEventsSpec.cs
+++ b/src/Domain/Specifications/CurrentTaskInstanceWithEventsSpec.cs
@@ -8,7 +8,7 @@ public sealed class CurrentTaskInstanceWithEventsSpec : Specification<TaskInstan
     public CurrentTaskInstanceWithEventsSpec(int id)
     {
         Query.Where(t => t.TaskId == id)
-            .Where(t => t.FinalState == null)
+            .Where(t => t.State == null)
             .Include(t => t.Events);
     }
 }

--- a/src/Domain/Specifications/JobNameUniquenessSpec.cs
+++ b/src/Domain/Specifications/JobNameUniquenessSpec.cs
@@ -1,0 +1,19 @@
+using Ardalis.Specification;
+using Domain.Entities;
+
+namespace Domain.Specifications;
+
+public sealed class JobNameUniquenessSpec : Specification<Job>
+{
+    public JobNameUniquenessSpec(string name, Job? existingJob)
+    {
+        if (existingJob is null)
+        {
+            Query.Where(j => j.Name == name);
+        }
+        else
+        {
+            Query.Where(j => j.Id != existingJob.Id && j.Name == name);
+        }
+    }
+}

--- a/src/Domain/Specifications/JobWithSpecificTaskSpec.cs
+++ b/src/Domain/Specifications/JobWithSpecificTaskSpec.cs
@@ -9,6 +9,8 @@ public sealed class JobWithSpecificTaskSpec : Specification<Job>, ISingleResultS
     {
         Query.Where(j => j.Id == id)
             .Include(job => job.Tasks.Where(t => t.Id == taskId))
+            .ThenInclude(t => t.Location)
+            .Include(job => job.Tasks.Where(t => t.Id == taskId))
             .ThenInclude(t => t.Objects)
             .Include(j => j.Tasks.Where(t => t.Id == taskId))
             .ThenInclude(t => t.Steps);

--- a/src/Domain/Specifications/LocationWithActiveTaskSpec.cs
+++ b/src/Domain/Specifications/LocationWithActiveTaskSpec.cs
@@ -1,0 +1,23 @@
+using Ardalis.Specification;
+using Domain.Common;
+using Domain.Entities.CompanyHierarchy;
+
+namespace Domain.Specifications;
+
+public sealed class LocationWithActiveTaskSpec : Specification<Location>
+{
+    public LocationWithActiveTaskSpec(int id)
+    {
+        Query.Where(l => l.Id == id)
+            .Include(l => l.Detector)
+            .Include(l => l.Tasks.Where(t => t.State != TaskState.Inactive))
+            .ThenInclude(t => t.Job)
+            .Include(l => l.Tasks.Where(t => t.State != TaskState.Inactive))
+            .ThenInclude(t => t.Steps)
+            .Include(l => l.Tasks.Where(t => t.State != TaskState.Inactive))
+            .ThenInclude(t => t.Objects)
+            .Include(l => l.Tasks.Where(t => t.State != TaskState.Inactive))
+            .ThenInclude(t => t.Instances.Where(ti => ti.FinalState == null))
+            .ThenInclude(ti => ti.Events);
+    }
+}

--- a/src/Domain/Specifications/LocationWithActiveTaskSpec.cs
+++ b/src/Domain/Specifications/LocationWithActiveTaskSpec.cs
@@ -10,14 +10,14 @@ public sealed class LocationWithActiveTaskSpec : Specification<Location>
     {
         Query.Where(l => l.Id == id)
             .Include(l => l.Detector)
-            .Include(l => l.Tasks.Where(t => t.State != TaskState.Inactive))
+            .Include(l => l.OngoingTask)
             .ThenInclude(t => t.Job)
-            .Include(l => l.Tasks.Where(t => t.State != TaskState.Inactive))
+            .Include(l => l.OngoingTask)
             .ThenInclude(t => t.Steps)
-            .Include(l => l.Tasks.Where(t => t.State != TaskState.Inactive))
+            .Include(l => l.OngoingTask)
             .ThenInclude(t => t.Objects)
-            .Include(l => l.Tasks.Where(t => t.State != TaskState.Inactive))
-            .ThenInclude(t => t.Instances.Where(ti => ti.FinalState == null))
+            .Include(l => l.OngoingTask)
+            .ThenInclude(t => t.OngoingInstance)
             .ThenInclude(ti => ti.Events);
     }
 }

--- a/src/Domain/Specifications/LocationWithDetectorSpec.cs
+++ b/src/Domain/Specifications/LocationWithDetectorSpec.cs
@@ -3,10 +3,11 @@ using Domain.Entities.CompanyHierarchy;
 
 namespace Domain.Specifications;
 
-public sealed class LocationWithDetectorSpec : Specification<Location>
+public sealed class LocationWithDetectorSpec : Specification<Location>, ISingleResultSpecification
 {
     public LocationWithDetectorSpec(int id)
     {
-        Query.Where(l => l.Id == id).Include(l => l.Detector);
+        Query.Where(l => l.Id == id)
+            .Include(l => l.Detector);
     }
 }

--- a/src/Domain/Specifications/TaskWithOngoingInstanceSpec.cs
+++ b/src/Domain/Specifications/TaskWithOngoingInstanceSpec.cs
@@ -1,0 +1,16 @@
+using Ardalis.Specification;
+using Task = Domain.Entities.TaskAggregate.Task;
+
+namespace Domain.Specifications;
+
+public sealed class TaskWithOngoingInstanceSpec : Specification<Task>, ISingleResultSpecification
+{
+    public TaskWithOngoingInstanceSpec(int id)
+    {
+        Query.Where(t => t.Id == id)
+            .Include(t => t.OngoingInstance)
+            .ThenInclude(t => t.Events)
+            .ThenInclude(e => e.Step)
+            .ThenInclude(s => s.Object);
+    }
+}

--- a/src/Infrastructure/Database/Context.cs
+++ b/src/Infrastructure/Database/Context.cs
@@ -38,18 +38,32 @@ public class Context : DbContext
             .WithOne(d => d.Location)
             .IsRequired(false)
             .OnDelete(DeleteBehavior.SetNull);
-        
+
+        modelBuilder.Entity<Location>()
+            .HasOne(l => l.OngoingTask)
+            .WithOne()
+            .HasForeignKey<Location>(l => l.OngoingTaskId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder.Entity<Task>()
+            .HasOne(t => t.OngoingInstance)
+            .WithOne()
+            .HasForeignKey<Task>(t => t.OngoingInstanceId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.SetNull);
+
         modelBuilder.Entity<TaskInstance>().Property(x => x.RemainingStepIds).HasConversion(new ValueConverter<int[], string>(
             i => string.Join(",", i),
             s => string.IsNullOrWhiteSpace(s) ? new int[0] : s.Split(new[] { ',' }).Select(v => int.Parse(v)).ToArray()));
-        
+
         modelBuilder.Entity<CalibrationCoordinates>().Property(x => x.Qr).HasConversion(new ValueConverter<int[], string>(
             i => string.Join(",", i),
             s => string.IsNullOrWhiteSpace(s) ? new int[0] : s.Split(new[] { ',' }).Select(v => int.Parse(v)).ToArray()));
-        
+
         modelBuilder.Entity<CalibrationCoordinates>().Property(x => x.Tray).HasConversion(new ValueConverter<int[], string>(
             i => string.Join(",", i),
             s => string.IsNullOrWhiteSpace(s) ? new int[0] : s.Split(new[] { ',' }).Select(v => int.Parse(v)).ToArray()));
-        
+
     }
 }

--- a/src/Infrastructure/Database/DbExt.cs
+++ b/src/Infrastructure/Database/DbExt.cs
@@ -28,7 +28,6 @@ public static class DbExt
 
         services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
         services.AddDbContext<Context>(dbOptions);
-        // services.AddDbContextFactory<Context>(dbOptions);
 
         return services;
     }

--- a/src/Infrastructure/Database/DbInitializer.cs
+++ b/src/Infrastructure/Database/DbInitializer.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -30,8 +31,18 @@ public static class DbInitializer
         if (env.IsDevelopment())
         {
             logger.Debug("Loading seed data");
-            // new SeedLoader(context, env, logger).Load(config);
-            new CodeSeedLoader(context).Load();
+
+            try
+            {
+                new CodeSeedLoader(context).Load();
+            }
+            catch (Exception)
+            {
+                // NOTE(rg): If anything goes wrong while seeding the database, it's probably unrecoverable.
+                // In this case we want to get rid of the empty database that was created
+                context.Database.EnsureDeleted();
+                throw;
+            }
         }
 
         logger.Debug("Database initialization finished");

--- a/src/Infrastructure/Database/JsonSeedLoader.cs
+++ b/src/Infrastructure/Database/JsonSeedLoader.cs
@@ -46,7 +46,7 @@ public class JsonSeedLoader
                 typeof(Event).GetProperty(nameof(Event.Timestamp))!, obj => DateTime.Parse(obj!.ToString()!)
             },
             {
-                typeof(TaskInstance).GetProperty(nameof(TaskInstance.FinalState))!, obj => obj == null ? null : Enum.Parse<TaskInstanceFinalState>(obj.ToString()!)
+                typeof(TaskInstance).GetProperty(nameof(TaskInstance.State))!, obj => obj == null ? null : Enum.Parse<TaskInstanceState>(obj.ToString()!)
             }
         };
     }

--- a/tests/ApiIntegrationTests/CompanyHierarchy/Locations/GetById.cs
+++ b/tests/ApiIntegrationTests/CompanyHierarchy/Locations/GetById.cs
@@ -26,16 +26,16 @@ public class GetById : IClassFixture<Setup>
         };
 
         var (response, result) = await _client.GETAsync<Endpoint, Endpoint.Req, Endpoint.Res>(req);
-        
+
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         Assert.NotNull(result);
         Assert.Equal("Location 1", result.Name);
         Assert.True(result.HasSnapshot);
 
         Assert.NotNull(result.OngoingTask);
-        Assert.Null(result.OngoingTask.TaskInstance);
+        Assert.NotNull(result.OngoingTask.OngoingInstance);
 
         req = new Endpoint.Req
         {

--- a/tests/ApiIntegrationTests/CompanyHierarchy/Locations/GetById.cs
+++ b/tests/ApiIntegrationTests/CompanyHierarchy/Locations/GetById.cs
@@ -32,7 +32,25 @@ public class GetById : IClassFixture<Setup>
         
         Assert.NotNull(result);
         Assert.Equal("Location 1", result.Name);
-        Assert.NotNull(result.Detector);
-        Assert.Equal("Detector 1", result.Detector.Name);
+        Assert.True(result.HasSnapshot);
+
+        Assert.NotNull(result.OngoingTask);
+        Assert.Null(result.OngoingTask.TaskInstance);
+
+        req = new Endpoint.Req
+        {
+            Id = 2
+        };
+
+        (response, result) = await _client.GETAsync<Endpoint, Endpoint.Req, Endpoint.Res>(req);
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.NotNull(result);
+        Assert.Equal("Location 2", result.Name);
+        Assert.False(result.HasSnapshot);
+
+        Assert.Null(result.OngoingTask);
     }
 }

--- a/tests/ApiIntegrationTests/Detectors/DetectorLifecycle.cs
+++ b/tests/ApiIntegrationTests/Detectors/DetectorLifecycle.cs
@@ -106,10 +106,7 @@ public class DetectorLifecycle : IClassFixture<Setup>
         Assert.NotNull(taskResponse);
         Assert.Equal(HttpStatusCode.OK, taskResponse.StatusCode);
         Assert.NotNull(taskResult);
-        Assert.Equal(TaskState.Inactive, taskResult.State);
-        Assert.NotNull(taskResult.LatestInstance);
-        Assert.Equal(TaskInstanceFinalState.Completed, taskResult.LatestInstance.FinalState);
-        Assert.Equal(3, taskResult.LatestInstance.Events.Count());
+        Assert.Null(taskResult.OngoingInstance);
 
         await DetectorStateIsCorrect(2, DetectorState.Standby);
     }

--- a/tests/ApiIntegrationTests/Detectors/DetectorLifecycle.cs
+++ b/tests/ApiIntegrationTests/Detectors/DetectorLifecycle.cs
@@ -1,7 +1,4 @@
 using System.Net;
-using System.Text;
-using System.Text.Json;
-using Api;
 using Domain.Common;
 using Domain.Common.DetectorCommand;
 using FastEndpoints;

--- a/tests/ApiIntegrationTests/Tasks/GetById.cs
+++ b/tests/ApiIntegrationTests/Tasks/GetById.cs
@@ -15,7 +15,7 @@ public class GetById : IClassFixture<Setup>
     {
         _client = setup.Client;
     }
-    
+
     [Fact]
     public async Task CanGetById()
     {
@@ -25,28 +25,28 @@ public class GetById : IClassFixture<Setup>
         };
 
         var (response, result) = await _client.GETAsync<Endpoint, Endpoint.Req, Endpoint.Res>(req);
-        
+
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         Assert.NotNull(result);
         Assert.Equal(1, result.Id);
         Assert.Equal("Task 1", result.Name);
-        Assert.Equal(TaskState.Active, result.State);
-        
-        Endpoint.Req req2 = new()
+        Assert.Null(result.OngoingInstance);
+
+        Endpoint.Req req3 = new()
         {
-            Id = 2
+            Id = 3
         };
 
-        var (response2, result2) = await _client.GETAsync<Endpoint, Endpoint.Req, Endpoint.Res>(req2);
-        
-        Assert.NotNull(response2);
-        Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
-        
-        Assert.NotNull(result2);
-        Assert.Equal(2, result2.Id);
-        Assert.Equal("Task 2", result2.Name);
-        Assert.Equal(TaskState.Inactive, result2.State);
+        var (response3, result3) = await _client.GETAsync<Endpoint, Endpoint.Req, Endpoint.Res>(req3);
+
+        Assert.NotNull(response3);
+        Assert.Equal(HttpStatusCode.OK, response3.StatusCode);
+
+        Assert.NotNull(result3);
+        Assert.Equal(3, result3.Id);
+        Assert.Equal("Task 3", result3.Name);
+        Assert.NotNull(result3.OngoingInstance);
     }
 }


### PR DESCRIPTION
Implement all tasks in #68, and also #67 (for now)

 -  `Step.orderNum` is no longer nullable. Its value must be 1 for fully unordered Tasks. Otherwise if we take the set of unique orderNums from a Task's Steps and sort them, the result must be a series from 1->n with step=1 (e..g 1,2,3,4,5 is valid but 1,2,5,6,9 isn't). Basically we're not allowed to skip orderNums. I think this makes more sense in general
 - `Task` contains and maintains `maxOrderNum` field. This is persisted to the DB
 - `TaskInstance` contains and maintains `currentOrderNum` field (because of the `orderNum` change, we can treat this as a progress indicator for where we are in the assembly sequence by comparing it to `maxOrderNum`). Also persisted to the DB
 - `Location` has an `ongoingTask?` field that points to the ongoing Task on the Location, if there is one. Persisted to the DB as a foreign key to `Task`. The backend makes sure this is always up to date. Previously we had to filter by `TaskState` on the list of the Location's Task, and *technically* is was possible to have more than 1 ongoing Task
 - `Task` has an `ongoingInstance?` field (serves the same purpose as `ongoingTask` above)
 - `Task.State` field has been removed. It's not needed anymore thanks to `ongoingTask`. Previously, both `Task` and `TaskInstance` had a `State` field, which I don't think was very clean (the Task itself doesn't really have a "state", we only care about its ongoing instance and whether it exists)
 - `TaskInstance.FinalState?` has been turned into `TaskInstance.State { Completed, Abandoned, InProgress, Paused }`. Basically I combined `Task.State` and `FinalState?`. It doesn't only encode the final state anymore so it must not be nullable
 - `Locations.GetById` now returns a lot more stuff. This is the endpoints that's called for data when navigating to a Location dashboard on the frontend. I might consider splitting this into smaller queries and have each dashboard panel have its own query (e.g. event list panel only asks for the events, next step guide only asks for the next step, etc.)
 - `Tasks.Update`: added a new constraint that only allows updating when the Task doesn't have an ongoing Instance. Updating a Task while it's running doesn't let the detector that's running the Task know about the changes, so when an Event is submitted by the detector, the data might be desynced between the detector and the BE (e.g. detector sends an Event for a Step that was deleted in the meantime).
 - `Job`: added a unique name constraint
 - Pushed some more logic into the domain model and changed property setters to be private where it made sense
 - Updated the seed data set with the new fields
 - Fixed all tests which were broken by the changes